### PR TITLE
Use b4a instead of node buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Base encodings for [protocol-buffers](https://github.com/mafintosh/protocol-buff
 npm install protocol-buffers-encodings
 ```
 
+Note: use Node.js >= 16.15.0 to avoid a performance regression due to a slower `Buffer.subarray` function.
+
 [![build status](https://travis-ci.org/mafintosh/protocol-buffers-encodings.svg?branch=master)](https://travis-ci.org/mafintosh/protocol-buffers-encodings)
 
 Moved into it's own module for lighter installs

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note: use Node.js >= 16.15.0 to avoid a performance regression due to a slower `
 
 [![build status](https://travis-ci.org/mafintosh/protocol-buffers-encodings.svg?branch=master)](https://travis-ci.org/mafintosh/protocol-buffers-encodings)
 
-Moved into it's own module for lighter installs
+Moved into its own module for lighter installs
 
 ## Usage
 
@@ -29,13 +29,13 @@ In general all encoders follow this API
 #### `buffer = enc.encode(value, buffer, offset)`
 
 Encode a value. `buffer` should be a buffer big enough to fit the value, `offset` should be the byte offset in the buffer where you want to write it.
-The buffer is returned for conveinience.
+The buffer is returned for convenience.
 
 After a value has been encoded `enc.encode.bytes` contains the amount of bytes used in the buffer.
 
 #### `value = enc.decode(buffer, offset)`
 
-Decode a value. `buffer` shoudl be an encoded value and `offset` should be the byte offset where you want to start decoding.
+Decode a value. `buffer` should be an encoded value and `offset` should be the byte offset where you want to start decoding.
 
 After a value has been decoded `enc.decode.bytes` contains the amount of bytes that was consumed from the buffer.
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ exports.bytes = encoder(2,
     var len = varint.decode(buffer, offset)
     offset += varint.decode.bytes
 
-    var val = buffer.slice(offset, offset + len)
+    var val = buffer.subarray(offset, offset + len)
     offset += val.length
 
     decode.bytes = offset - oldOffset
@@ -198,7 +198,7 @@ exports.sfixed64 = encoder(1,
     return buffer
   },
   function decode (buffer, offset) {
-    var val = buffer.slice(offset, offset + 8)
+    var val = buffer.subarray(offset, offset + 8)
     decode.bytes = 8
     return val
   },

--- a/index.js
+++ b/index.js
@@ -209,12 +209,12 @@ exports.sfixed64 = encoder(1,
 
 exports.double = encoder(1,
   function encode (val, buffer, offset) {
-    buffer.writeDoubleLE(val, offset)
+    b4a.writeDoubleLE(buffer, val, offset)
     encode.bytes = 8
     return buffer
   },
   function decode (buffer, offset) {
-    var val = buffer.readDoubleLE(offset)
+    var val = b4a.readDoubleLE(buffer, offset)
     decode.bytes = 8
     return val
   },
@@ -225,12 +225,12 @@ exports.double = encoder(1,
 
 exports.fixed32 = encoder(5,
   function encode (val, buffer, offset) {
-    buffer.writeUInt32LE(val, offset)
+    b4a.writeUInt32LE(buffer, val, offset)
     encode.bytes = 4
     return buffer
   },
   function decode (buffer, offset) {
-    var val = buffer.readUInt32LE(offset)
+    var val = b4a.readUInt32LE(buffer, offset)
     decode.bytes = 4
     return val
   },
@@ -241,12 +241,12 @@ exports.fixed32 = encoder(5,
 
 exports.sfixed32 = encoder(5,
   function encode (val, buffer, offset) {
-    buffer.writeInt32LE(val, offset)
+    b4a.writeInt32LE(buffer, val, offset)
     encode.bytes = 4
     return buffer
   },
   function decode (buffer, offset) {
-    var val = buffer.readInt32LE(offset)
+    var val = b4a.readInt32LE(buffer, offset)
     decode.bytes = 4
     return val
   },
@@ -257,12 +257,12 @@ exports.sfixed32 = encoder(5,
 
 exports.float = encoder(5,
   function encode (val, buffer, offset) {
-    buffer.writeFloatLE(val, offset)
+    b4a.writeFloatLE(buffer, val, offset)
     encode.bytes = 4
     return buffer
   },
   function decode (buffer, offset) {
-    var val = buffer.readFloatLE(offset)
+    var val = b4a.readFloatLE(buffer, offset)
     decode.bytes = 4
     return val
   },

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var varint = require('varint')
 var svarint = require('signed-varint')
+var b4a = require('b4a')
 
 exports.make = encoder
 
@@ -43,8 +44,8 @@ exports.bytes = encoder(2,
     varint.encode(len, buffer, offset)
     offset += varint.encode.bytes
 
-    if (Buffer.isBuffer(val)) val.copy(buffer, offset)
-    else buffer.write(val, offset, len)
+    if (b4a.isBuffer(val)) b4a.copy(val, buffer, offset)
+    else b4a.write(buffer, val, offset, len)
     offset += len
 
     encode.bytes = offset - oldOffset
@@ -71,12 +72,12 @@ exports.bytes = encoder(2,
 exports.string = encoder(2,
   function encode (val, buffer, offset) {
     var oldOffset = offset
-    var len = Buffer.byteLength(val)
+    var len = b4a.byteLength(val)
 
     varint.encode(len, buffer, offset, 'utf-8')
     offset += varint.encode.bytes
 
-    buffer.write(val, offset, len)
+    b4a.write(buffer, val, offset, len)
     offset += len
 
     encode.bytes = offset - oldOffset
@@ -88,14 +89,14 @@ exports.string = encoder(2,
     var len = varint.decode(buffer, offset)
     offset += varint.decode.bytes
 
-    var val = buffer.toString('utf-8', offset, offset + len)
+    var val = b4a.toString(buffer, 'utf-8', offset, offset + len)
     offset += len
 
     decode.bytes = offset - oldOffset
     return val
   },
   function encodingLength (val) {
-    var len = Buffer.byteLength(val)
+    var len = b4a.byteLength(val)
     return varint.encodingLength(len) + len
   }
 )
@@ -157,8 +158,8 @@ exports.int64 = encoder(0,
       var limit = 9
       while (buffer[offset + limit - 1] === 0xff) limit--
       limit = limit || 9
-      var subset = Buffer.allocUnsafe(limit)
-      buffer.copy(subset, 0, offset, offset + limit)
+      var subset = b4a.allocUnsafe(limit)
+      b4a.copy(buffer, subset, 0, offset, offset + limit)
       subset[limit - 1] = subset[limit - 1] & 0x7f
       val = -1 * varint.decode(subset, 0)
       decode.bytes = 10
@@ -192,7 +193,7 @@ exports.varint = encoder(0,
 exports.fixed64 =
 exports.sfixed64 = encoder(1,
   function encode (val, buffer, offset) {
-    val.copy(buffer, offset)
+    b4a.copy(val, buffer, offset)
     encode.bytes = 8
     return buffer
   },
@@ -282,5 +283,5 @@ function encoder (type, encode, decode, encodingLength) {
 }
 
 function bufferLength (val) {
-  return Buffer.isBuffer(val) ? val.length : Buffer.byteLength(val)
+  return b4a.isBuffer(val) ? val.length : b4a.byteLength(val)
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Base encodings for protocol-buffers",
   "main": "index.js",
   "dependencies": {
-    "b4a": "^1.5.3",
+    "b4a": "^1.6.0",
     "signed-varint": "^2.0.1",
     "varint": "5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Base encodings for protocol-buffers",
   "main": "index.js",
   "dependencies": {
+    "b4a": "^1.5.3",
     "signed-varint": "^2.0.1",
     "varint": "5.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -71,25 +71,20 @@ tape('fixed64 (browser style)', function (t) {
   )
 })
 
-
- tape('double', function (t) {
+tape('double', function (t) {
   test(t, encodings.double, [0, 2, 0.5, 0.4])
-  // TODO: Fails because writeDoubleLE is not supported by b4a
 })
 
 tape('float', function (t) {
   test(t, encodings.float, [0, 2, 0.5])
-  // TODO: Fails because writeFloatLE is not supported by b4a
 })
 
 tape('fixed32', function (t) {
   test(t, encodings.fixed32, [4, 0, 10000])
-  // TODO: Fails because writeUInt32LE is not supported by b4a
 })
 
 tape('sfixed32', function (t) {
   test(t, encodings.sfixed32, [-100, 4, 0, 142425])
-  // TODO: Fails because writeInt32LE is not supported by b4a
 })
 
 function test (t, enc, vals, allocFunctions = [allocBuffer, allocUint8Array]) {

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ tape('string', function (t) {
 
 tape('bytes', function (t) {
   test(t, encodings.bytes, [Buffer.alloc(4096), Buffer.from('hi')])
+  // TODO: Fails because it is a Buffer. Manually add Uint8Array option?
 })
 
 tape('bool', function (t) {
@@ -41,46 +42,84 @@ tape('uint64', function (t) {
 
 tape('fixed64', function (t) {
   test(t, encodings.fixed64, [Buffer.from([0, 0, 0, 0, 0, 0, 0, 1])])
+  // TODO: Fails because it is a Buffer. Manually add Uint8Array option?
 })
 
 tape('double', function (t) {
   test(t, encodings.double, [0, 2, 0.5, 0.4])
+  // TODO: Fails because writeDoubleLE is not supported by b4a
 })
 
 tape('float', function (t) {
   test(t, encodings.float, [0, 2, 0.5])
+  // TODO: Fails because writeFloatLE is not supported by b4a
 })
 
 tape('fixed32', function (t) {
   test(t, encodings.fixed32, [4, 0, 10000])
+  // TODO: Fails because writeUInt32LE is not supported by b4a
 })
 
 tape('sfixed32', function (t) {
   test(t, encodings.sfixed32, [-100, 4, 0, 142425])
+  // TODO: Fails because writeInt32LE is not supported by b4a
 })
 
 function test (t, enc, vals) {
   if (!Array.isArray(vals)) vals = [vals]
 
-  for (var i = 0; i < vals.length; i++) {
-    var val = vals[i]
-    var buf = Buffer.alloc(enc.encodingLength(val))
+  var allocFunctions = [
+    (length) => Buffer.alloc(length), // Node style
+    (length) => new Uint8Array(length) // Browser style
+  ]
 
-    enc.encode(val, buf, 0)
+  for (var allocFunction of allocFunctions) {
+    for (var i = 0; i < vals.length; i++) {
+      var val = vals[i]
+      var buf = allocFunction(enc.encodingLength(val))
 
-    t.same(enc.encode.bytes, buf.length)
-    t.same(enc.encodingLength(val), buf.length)
-    t.same(enc.decode(buf, 0), val)
-    t.same(enc.decode.bytes, buf.length)
+      enc.encode(val, buf, 0)
 
-    var anotherBuf = Buffer.alloc(enc.encodingLength(val) + 1000)
+      t.same(enc.encode.bytes, buf.length)
+      t.same(enc.encodingLength(val), buf.length)
+      t.same(enc.decode(buf, 0), val)
+      t.same(enc.decode.bytes, buf.length)
 
-    buf = enc.encode(val, anotherBuf, 10)
-    t.same(buf, anotherBuf)
-    t.ok(enc.encode.bytes < anotherBuf.length)
-    t.same(enc.decode(buf, 10, 10 + enc.encodingLength(val)), val)
-    t.ok(enc.decode.bytes < anotherBuf.length)
+      var anotherBuf = allocFunction(enc.encodingLength(val) + 1000)
+
+      buf = enc.encode(val, anotherBuf, 10)
+      t.same(buf, anotherBuf)
+      t.ok(enc.encode.bytes < anotherBuf.length)
+      t.same(enc.decode(buf, 10, 10 + enc.encodingLength(val)), val)
+      t.ok(enc.decode.bytes < anotherBuf.length)
+    }
   }
 
   t.end()
 }
+
+tape('test browser-style buffer', function (t) {
+  var enc = encodings.string
+  var val = 'value'
+  var buf = new Uint8Array(enc.encodingLength(val))
+  enc.encode(val, buf, 0)
+
+  // First elem is the length (5). Others are the encoded 'value'
+  var expectedEncodedVal = new Uint8Array([5, 118, 97, 108, 117, 101])
+  t.same(buf, expectedEncodedVal)
+
+  t.same(enc.encode.bytes, buf.length)
+  t.same(enc.encodingLength(val), buf.length)
+  t.same(enc.decode(buf, 0), val)
+  t.same(enc.decode.bytes, buf.length)
+
+  var anotherBuf = new Uint8Array(enc.encodingLength(val) + 1000)
+
+  buf = enc.encode(val, anotherBuf, 10)
+  t.same(buf, anotherBuf)
+  t.ok(enc.encode.bytes < anotherBuf.length)
+  t.same(enc.decode(buf, 10, 10 + enc.encodingLength(val)), val)
+  t.ok(enc.decode.bytes < anotherBuf.length)
+
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -15,9 +15,22 @@ tape('string', function (t) {
   test(t, encodings.string, ['a', 'abefest', 'øøø'])
 })
 
-tape('bytes', function (t) {
-  test(t, encodings.bytes, [Buffer.alloc(4096), Buffer.from('hi')])
-  // TODO: Fails because it is a Buffer. Manually add Uint8Array option?
+tape('bytes (node style)', function (t) {
+  test(
+    t,
+    encodings.bytes,
+    [Buffer.alloc(4096), Buffer.from('hi')],
+    [allocBuffer]
+  )
+})
+
+tape('bytes (browser style)', function (t) {
+  test(
+    t,
+    encodings.bytes,
+    [new Uint8Array(4096), new Uint8Array([104, 105])],
+    [allocUint8Array]
+  )
 })
 
 tape('bool', function (t) {
@@ -40,12 +53,26 @@ tape('uint64', function (t) {
   test(t, encodings.uint64, [1, 0, 144, 424444, 4203595524])
 })
 
-tape('fixed64', function (t) {
-  test(t, encodings.fixed64, [Buffer.from([0, 0, 0, 0, 0, 0, 0, 1])])
-  // TODO: Fails because it is a Buffer. Manually add Uint8Array option?
+tape('fixed64 (node style)', function (t) {
+  test(
+    t,
+    encodings.fixed64,
+    [Buffer.from([0, 0, 0, 0, 0, 0, 0, 1])],
+    [allocBuffer]
+  )
 })
 
-tape('double', function (t) {
+tape('fixed64 (browser style)', function (t) {
+  test(
+    t,
+    encodings.fixed64,
+    [new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1])],
+    [allocUint8Array]
+  )
+})
+
+
+ tape('double', function (t) {
   test(t, encodings.double, [0, 2, 0.5, 0.4])
   // TODO: Fails because writeDoubleLE is not supported by b4a
 })
@@ -65,18 +92,13 @@ tape('sfixed32', function (t) {
   // TODO: Fails because writeInt32LE is not supported by b4a
 })
 
-function test (t, enc, vals) {
+function test (t, enc, vals, allocFunctions = [allocBuffer, allocUint8Array]) {
   if (!Array.isArray(vals)) vals = [vals]
 
-  var allocFunctions = [
-    (length) => Buffer.alloc(length), // Node style
-    (length) => new Uint8Array(length) // Browser style
-  ]
-
-  for (var allocFunction of allocFunctions) {
+  for (const allocFunction of allocFunctions) {
     for (var i = 0; i < vals.length; i++) {
-      var val = vals[i]
-      var buf = allocFunction(enc.encodingLength(val))
+      const val = vals[i]
+      let buf = allocFunction(enc.encodingLength(val))
 
       enc.encode(val, buf, 0)
 
@@ -85,7 +107,7 @@ function test (t, enc, vals) {
       t.same(enc.decode(buf, 0), val)
       t.same(enc.decode.bytes, buf.length)
 
-      var anotherBuf = allocFunction(enc.encodingLength(val) + 1000)
+      const anotherBuf = allocFunction(enc.encodingLength(val) + 1000)
 
       buf = enc.encode(val, anotherBuf, 10)
       t.same(buf, anotherBuf)
@@ -99,13 +121,13 @@ function test (t, enc, vals) {
 }
 
 tape('test browser-style buffer', function (t) {
-  var enc = encodings.string
-  var val = 'value'
-  var buf = new Uint8Array(enc.encodingLength(val))
+  const enc = encodings.string
+  const val = 'value'
+  let buf = new Uint8Array(enc.encodingLength(val))
   enc.encode(val, buf, 0)
 
   // First elem is the length (5). Others are the encoded 'value'
-  var expectedEncodedVal = new Uint8Array([5, 118, 97, 108, 117, 101])
+  const expectedEncodedVal = new Uint8Array([5, 118, 97, 108, 117, 101])
   t.same(buf, expectedEncodedVal)
 
   t.same(enc.encode.bytes, buf.length)
@@ -113,7 +135,7 @@ tape('test browser-style buffer', function (t) {
   t.same(enc.decode(buf, 0), val)
   t.same(enc.decode.bytes, buf.length)
 
-  var anotherBuf = new Uint8Array(enc.encodingLength(val) + 1000)
+  const anotherBuf = new Uint8Array(enc.encodingLength(val) + 1000)
 
   buf = enc.encode(val, anotherBuf, 10)
   t.same(buf, anotherBuf)
@@ -123,3 +145,13 @@ tape('test browser-style buffer', function (t) {
 
   t.end()
 })
+
+function allocBuffer (length) {
+  // Node style
+  return Buffer.alloc(length)
+}
+
+function allocUint8Array (length) {
+  // Browser style
+  return new Uint8Array(length)
+}

--- a/test.js
+++ b/test.js
@@ -91,8 +91,7 @@ function test (t, enc, vals, allocFunctions = [allocBuffer, allocUint8Array]) {
   if (!Array.isArray(vals)) vals = [vals]
 
   for (const allocFunction of allocFunctions) {
-    for (var i = 0; i < vals.length; i++) {
-      const val = vals[i]
+    for (const val of vals) {
       let buf = allocFunction(enc.encodingLength(val))
 
       enc.encode(val, buf, 0)


### PR DESCRIPTION
- Replaced all occurrences of buffer functions which have a replacement in b4a. 
- Duplicated all tests so they also run with Uint8Arrays 
- Added an additional low-level test test for Uint8Array string case (might be redundant, I used it to develop my understanding)

Currently the tests are conservative: they test if UInt8Arrays can be used everywhere. I indicated with TODOs where tests are failing. If Uint8Array support is not (urgently) needed there, I can remove those tests.

Note: this module uses some Buffer methods which do not yet exist in b4a:
- writeDoubleLE
- writeUInt32LE
- writeInt32LE
- writeFloatLE

I can add these to b4a if that makes sense. This would resolve most of the failing tests.

Other tests fail because a Buffer is directly used when defining the values. I could explicitly add a Uint8Array there instead, but want to check first if it makes sense


